### PR TITLE
はてなスター AutoPagerize 処理で JavaScript エラーがでないようにしました

### DIFF
--- a/plugin/hatena_star.rb
+++ b/plugin/hatena_star.rb
@@ -22,6 +22,10 @@ add_header_proc do
 			}
 		};
 		(function() {
+			if (!window.addEventListener) {
+				return;
+			}
+
 			var NodeInsert = function(evt) {
 				Hatena.Star.EntryLoader.loadNewEntries(evt.target);
 			};


### PR DESCRIPTION
以前取り込んでもらったのですが、 IE のことをすっかり忘れていて、 JavaScript エラーが出ていましたので修正しました。
