### PR TITLE
section_permalinkプラグインはJavaScriptオフでもスクロールして欲しい

### DIFF
--- a/plugin/section_permalink.rb
+++ b/plugin/section_permalink.rb
@@ -16,7 +16,7 @@ def anchor( s )
 			s1 = $1
 			s2 = $2
 			if $2 =~ /^p/
-				"?date=#{s1}&p=#{s2.gsub(/p/, '')}"
+				"?date=#{s1}&p=#{s2.gsub(/p/, '')}##{s2}"
 			else
 				"?date=#{s1}.html##{s2}"
 			end

--- a/plugin/section_permalink_anchor.rb
+++ b/plugin/section_permalink_anchor.rb
@@ -18,7 +18,7 @@ def anchor( s )
 			s1 = $1
 			s2 = $2
 			if $2 =~ /^p/
-				"#{s1}#{s2}.html"
+				"#{s1}#{s2}.html##{s2}"
 			else
 				"#{s1}.html##{s2}"
 			end


### PR DESCRIPTION
プラグインの
- section_permalink.rb
- section_permalink_anchor.rb

には、「セクションに飛ぶとそこにスクロールします」という機能がありますが、JavaScriptを無効にしているとスクロールしてくれません。

また、私が試した環境では、Chrome以外のブラウザ（IE, Firefox, Opera）ではJavaScriptを有効にしていてもスクロールしてくれないようでした。

URLにフラグメント識別子を付ければJavaScriptがオフでもスクロールするようになると思うので、そのような修正をpull requestしてみます。
