### PR TITLE
estraier-search: TDiary::Config::new arity changed.

### DIFF
--- a/util/estraier-search/estraier-register.rb
+++ b/util/estraier-search/estraier-register.rb
@@ -231,7 +231,7 @@ end
 if mode == "CMD"
 	begin
 		require 'cgi'
-		if TDiary::Config.instance_method(:initialize).arity > 0
+		if TDiary::Config.instance_method(:initialize).arity != 0
 			# for tDiary 2.1 or later
 			cgi = CGI.new
 			conf = TDiary::Config::new(cgi)

--- a/util/estraier-search/estraier-search.rb
+++ b/util/estraier-search/estraier-search.rb
@@ -230,7 +230,7 @@ end
 
 begin
 	@cgi = CGI::new
-	if ::TDiary::Config.instance_method(:initialize).arity > 0
+	if ::TDiary::Config.instance_method(:initialize).arity != 0
 		# for tDiary 2.1 or later
 		conf = ::TDiary::Config::new(@cgi)
 	else


### PR DESCRIPTION
tdiary/tdiary-core@1738964873d58bac736ec2b30f685c766ffc669c で
TDiary::Config::new の引数の取り方が変わって

``` ruby
TDiary::Config.instance_method(:initialize).arity
```

が1から-2に変わってしまったため、estraier-register.rb と estraier-search.rb が動かなくなっていました。
