### PR TITLE
Use iframe for embedding Ustream player

### DIFF
--- a/plugin/ustream.rb
+++ b/plugin/ustream.rb
@@ -15,8 +15,5 @@ def ustream( id, type = :recorded )
 		return %Q|<a href="http://www.ustream.tv/recorded/#{id}">Link to Ustream ##{id}</a></p><p>|
 	end
 
-	# flashvars+="locale=(ja_JP|en_US)"
-	utv_id = "utv#{rand(1000000)}"
-	utv_name = "utv_n_#{rand(1000000)}"
-	%Q|<object class="ustream" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" width="480" height="386" id="#{utv_id}" name="#{utv_name}"><param name="flashvars" value="autoplay=false"><param name="allowfullscreen" value="true"><param name="allowscriptaccess" value="always"><param name="src" value="http://www.ustream.tv/flash/video/#{id}"><embed flashvars="autoplay=false" width="480" height="386" allowfullscreen="true" allowscriptaccess="always" id="#{utv_id}" name="#{utv_name}" src="http://www.ustream.tv/flash/video/#{id}" type="application/x-shockwave-flash"></embed></object>|
+	%Q|<iframe class="ustream" width="480" height="302" src="http://www.ustream.tv/embed/recorded/#{id}?v=3&amp;wmode=direct" scrolling="no" frameborder="0" style="border: 0px none transparent;"></iframe>|
 end


### PR DESCRIPTION
Because the official site generates iframe tag instead of object tag
for embedding.

Try clicking "share" button in player.

For example, http://www.ustream.tv/recorded/25451894 generates the following tag:

```
<iframe width="480" height="302" src="http://www.ustream.tv/embed/recorded/25451894?v=3&amp;wmode=direct" scrolling="no" frameborder="0" style="border: 0px none transparent;">    </iframe>
<br /><a href="http://www.ustream.tv/" style="padding: 2px 0px 4px; width: 400px; background: #ffffff; display: block; color: #000000; font-weight: normal; font-size: 10px; text-decoration: underline; text-align: center;" target="_blank">Video streaming by Ustream</a>
```

This change doesn't include `<a>` tag because the original code doesn't include it.
