### PR TITLE
github へのリンクを作るプラグインを作成した

### DIFF
--- a/plugin/github_link.rb
+++ b/plugin/github_link.rb
@@ -1,0 +1,9 @@
+def gh_link(gh_identifier)
+	text = gh_identifier.split('/').last
+	id_and_name, number = gh_identifier.split('#')
+
+	url = "https://github.com/#{id_and_name}"
+	url = url + "/issues/#{number}" if number
+
+	"<a href='#{url}'>#{text}</a>"
+end

--- a/spec/github_link_spec.rb
+++ b/spec/github_link_spec.rb
@@ -1,0 +1,23 @@
+$:.unshift(File.dirname(__FILE__))
+require 'spec_helper'
+
+describe "github link plugin" do
+	let(:plugin) { fake_plugin(:github_link) }
+	subject { plugin.gh_link(arg) }
+
+	describe 'repository page' do
+		let(:arg) { 'tdiary/tdiary-contrib' }
+
+		it 'should render repository a tag' do
+			should == %(<a href='https://github.com/tdiary/tdiary-contrib'>tdiary-contrib</a>)
+		end
+	end
+
+	describe 'issues page' do
+		let(:arg) { 'tdiary/tdiary-contrib#100' }
+
+		it 'should render issues a tag' do
+			should == %(<a href='https://github.com/tdiary/tdiary-contrib/issues/100'>tdiary-contrib#100</a>)
+		end
+	end
+end


### PR DESCRIPTION
`tdiary/tdiary-contrib` と書いたら https://github.com/tdiary/tdiary-contrib にリンクを作成するプラグインを作りました。
`tdiary/tdiary-contrib#100` と書いた場合、issues へのリンクになるようにしています。
