### PR TITLE
instagr.rbでシンボルじゃないと配列にマッチしないので常に:mediumになっていた問題を修正

### DIFF
--- a/plugin/instagr.rb
+++ b/plugin/instagr.rb
@@ -23,6 +23,7 @@ def instagr( short_url, size = :medium)
 	option = option.nil? ? {} : option
 	
 	# img size
+	size = size.to_sym if size != :medium
 	maxwidth_data = {:small => 150, :medium => 306, :large => 612}
 	maxwidth = maxwidth_data[ size ] ? maxwidth_data[ size ] : maxwidth_data[:medium]
 	


### PR DESCRIPTION
初pull request & ruby初心者でイマイチわかってないかもしれませんがお願いします。

日記でinstagr.rbプラグインの画像サイズに文字列を指定して渡しても、シンボルとして処理されず、配列添字にマッチしないで画像サイズが常に:mediumとして処理されてしまうのを修正しました。
