### PR TITLE
support style-namespace for search-default.rb

### DIFF
--- a/plugin/search-default.rb
+++ b/plugin/search-default.rb
@@ -100,7 +100,7 @@ module DefaultIOSearch
 		c = DIARY_CLASS_CACHE[style]
 		return c if c
 		require "tdiary/style/#{style.downcase}_style.rb"
-		c = eval("TDiary::#{style.capitalize}Diary")
+		c = TDiary.const_defined?('Style') ? eval("TDiary::Style::#{style.capitalize}Diary") : eval("TDiary::#{style.capitalize}Diary")
 		c.__send__(:include, DiaryClassDelta)
 		DIARY_CLASS_CACHE[style] = c
 		c


### PR DESCRIPTION
tdiary-core 側での Style namespace の導入に伴い、
search-default.rb プラグインでの検索実行時に以下の例外が起きるようになりました。
（GFMスタイルで日記を書いていましたが、他のスタイルでも例外になると思います）

```
NameError
uninitialized constant TDiary::GfmDiary
(plugin/search-default.rb):103:in `eval'
(plugin/search-default.rb):103:in `eval'
(plugin/search-default.rb):103:in `diary_class'
(plugin/search-default.rb):85:in `block in read_diaries'
(plugin/search-default.rb):154:in `block (2 levels) in load_tdiary_textdb'
(plugin/search-default.rb):143:in `each'
(plugin/search-default.rb):143:in `block in load_tdiary_textdb'
(plugin/search-default.rb):140:in `open'
(plugin/search-default.rb):140:in `load_tdiary_textdb'
```

TDiary::Style が定義されていればそちらを参照するように変更しました。
