### PR TITLE
fix twitter link

### DIFF
--- a/js/socialbutton.js
+++ b/js/socialbutton.js
@@ -27,8 +27,13 @@ $(function() {
   // set options for jQuery.socialbutton
   var callbacks = {
     twitter: function(url, title) {
+      var link = url;
+      var pos = 0;
+      if ((pos = url.indexOf('#')) > 0) {
+        link = url.substr(0, pos)
+      }
       return {
-        url: url,
+        url: link,
         text: title,
         button: 'horizontal',
         lang: $('html').attr('lang').substr(0,2)


### PR DESCRIPTION
TwitterのURL検索は'＃'以下のコンテキスト内リンクを認識しないので除外したい。
