### PR TITLE
search-default.rb: support io namespace (introduced in tdiary 4.0.2)

### DIFF
--- a/plugin/search-default.rb
+++ b/plugin/search-default.rb
@@ -99,8 +99,13 @@ module DefaultIOSearch
 	def diary_class(style)
 		c = DIARY_CLASS_CACHE[style]
 		return c if c
-		require "tdiary/style/#{style.downcase}_style.rb"
-		c = TDiary.const_defined?('Style') ? eval("TDiary::Style::#{style.capitalize}Diary") : eval("TDiary::#{style.capitalize}Diary")
+		if TDiary.const_defined?('Style')
+			require "tdiary/style/#{style.downcase}.rb"
+			c = eval("TDiary::Style::#{style.capitalize}Diary")
+		else
+			require "tdiary/style/#{style.downcase}_style.rb"
+			c = eval("TDiary::#{style.capitalize}Diary")
+		end
 		c.__send__(:include, DiaryClassDelta)
 		DIARY_CLASS_CACHE[style] = c
 		c


### PR DESCRIPTION
tDiary 4.0.2 で search-default.rb プラグインで検索を行うと、Plugin Error (NameError
uninitialized constant TDiary::DefaultIO) になる問題を修正しました。

検索時に表示される例外の情報は以下の通りです。

```
Plugin Error

Errors in plugins? Retry to Update or Configure.

NameError
uninitialized constant TDiary::DefaultIO
(plugin/search-default.rb):230:in `search_result'
(TDiary::Plugin#eval_src):19:in `block in eval_src'
/tmp/t/tdiary/plugin.rb:99:in `eval'
/tmp/t/tdiary/plugin.rb:99:in `block in eval_src'
/tmp/t/tdiary/core_ext.rb:112:in `block in safe'
/tmp/t/tdiary/core_ext.rb:106:in `call'
/tmp/t/tdiary/core_ext.rb:106:in `safe'
/tmp/t/tdiary/plugin.rb:98:in `eval_src'
/tmp/t/tdiary/base.rb:66:in `do_eval_rhtml'
/tmp/t/tdiary/base.rb:30:in `eval_rhtml'
/tmp/t/tdiary/dispatcher/index_main.rb:43:in `run'
/tmp/t/tdiary/dispatcher/index_main.rb:6:in `run'
/tmp/t/tdiary/dispatcher.rb:26:in `dispatch_cgi'
/tmp/t/tdiary/dispatcher.rb:21:in `call'
/tmp/t/tdiary/rack/valid_request_path.rb:17:in `block in call'
/tmp/t/tdiary/rack/valid_request_path.rb:16:in `each'
/tmp/t/tdiary/rack/valid_request_path.rb:16:in `call'
/tmp/t/tdiary/rack/static.rb:15:in `call'
/tmp/t/tdiary/rack/html_anchor.rb:20:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `block in call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `each'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:65:in `block in call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `each'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/urlmap.rb:50:in `call'
/tmp/t/tdiary/application.rb:39:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/reloader.rb:44:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/lint.rb:49:in `_call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/lint.rb:37:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/showexceptions.rb:24:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/commonlogger.rb:33:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/chunked.rb:43:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/content_length.rb:14:in `call'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/thin-1.6.1/lib/thin/connection.rb:82:in `block in pre_process'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/thin-1.6.1/lib/thin/connection.rb:80:in `catch'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/thin-1.6.1/lib/thin/connection.rb:80:in `pre_process'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/thin-1.6.1/lib/thin/connection.rb:55:in `process'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/thin-1.6.1/lib/thin/connection.rb:41:in `receive_data'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run_machine'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/thin-1.6.1/lib/thin/backends/base.rb:73:in `start'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/thin-1.6.1/lib/thin/server.rb:162:in `start'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/handler/thin.rb:16:in `run'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/server.rb:264:in `start'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/lib/rack/server.rb:141:in `start'
/tmp/t/vendor/bundle/ruby/1.9.1/gems/rack-1.5.2/bin/rackup:4:in `<top (required)>'
/tmp/t/vendor/bundle/ruby/1.9.1/bin/rackup:23:in `load'
/tmp/t/vendor/bundle/ruby/1.9.1/bin/rackup:23:in `<main>'
```

この修正では、tDiary 4.0.0 でも動作することを確認してあります。
