### PR TITLE
Revert "changing tDiary initialization process"

### DIFF
--- a/lib/extensions/contrib.rb
+++ b/lib/extensions/contrib.rb
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+module TDiary
+	module Extensions
+		class Contrib
+			def self.sp_path
+				File.join(TDiary::Contrib.root, 'plugin')
+			end
+
+			def self.assets_path
+				File.join(TDiary::Contrib.root, 'js')
+			end
+		end
+	end
+end

--- a/lib/tdiary-contrib.rb
+++ b/lib/tdiary-contrib.rb
@@ -1,19 +1,10 @@
+# -*- coding: utf-8 -*-
+require 'extensions/contrib'
+
 module TDiary
 	class Contrib
 		def self.root
 			File.expand_path('../..', __FILE__)
-		end
-
-		class Assets
-			def self.setup(environment)
-				environment.append_path File.join(TDiary::Contrib.root, 'js')
-			end
-		end
-
-		class Plugin
-			def self.setup(sp_path)
-				sp_path << File.join(TDiary::Contrib.root, 'plugin')
-			end
 		end
 	end
 end


### PR DESCRIPTION
tdiary/tdiary-core#375 への対処です。
tdiary-contribからtdiary/application.rbを参照するのをやめて、tdiary/applicationがtdiary-contribを参照するようにしました（以前の方式に戻しています）。

※ tdiary-core側も一緒に更新しないと動作しません。
