### PR TITLE
fix for "Contrib is not a class"

### DIFF
--- a/lib/tdiary/contrib/version.rb
+++ b/lib/tdiary/contrib/version.rb
@@ -1,5 +1,5 @@
 module TDiary
-  module Contrib
+  class Contrib
     VERSION = "4.0.2.1"
   end
 end


### PR DESCRIPTION
tdiary-core のmaster最新 (918f0651b27510db2fc6a8055f4c027483b35d42)とtdiary-contrib のmaster最新(732c2fe639d0d3d49d1e9ec42620036c25822555)の環境では、
`Contrib is not a class` という例外が起きます。

tdiary/tdiary-contrib#75 の修正で追加された lib/tdiary/contrib/version.rb を、
もともと存在した lib/tdiary-contrib.rb にあわせる形で修正しました。
