### PR TITLE
tdiary-core のアセットが見えない(404 not found)問題を修正しました

### DIFF
--- a/lib/extensions/contrib.rb
+++ b/lib/extensions/contrib.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+require 'tdiary/extensions'
 
 module TDiary
 	module Extensions


### PR DESCRIPTION
https://github.com/tdiary/tdiary-core/issues/394
の修正により、tdiary-coreとtdiary-contribをRackで動かしているときに
tdiary-coreのアセットが404で見えない問題を修正しました。

（tdiary/extensions がロードされずに tdiary-contrib 側で TDiary::Extensions が定義されてしまうため、
tdiary/extensions/core がロードされていなかった、ということのようです）
