### PR TITLE
ignore version of core gem

### DIFF
--- a/tdiary-contrib.gemspec
+++ b/tdiary-contrib.gemspec
@@ -2,7 +2,6 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'tdiary/contrib/version'
-require 'tdiary/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "tdiary-contrib"
@@ -19,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'tdiary', ">= #{TDiary::VERSION}"
+  spec.add_dependency 'tdiary'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
開発中はcoreのGemfileに「gem 'tdiary-contrib', path: '../contrib'」とか書きたくなるのだけど、contribがcore gemのバージョンチェックをしているせいでうまくbundleできません。いっそ無視しちゃってもいいんじゃないかと思うのだけど、どうでしょう? @machu 
