### PR TITLE
Use https on flickr api

### DIFF
--- a/plugin/flickr.rb
+++ b/plugin/flickr.rb
@@ -183,7 +183,6 @@ module Flickr
       Net::HTTP.version_1_2
       https = Net::HTTP.new('www.flickr.com', 443)
       https.use_ssl = true
-      https.verify_mode = OpenSSL::SSL::VERIFY_PEER
       https.start {
         response = https.get(query)
         response.body


### PR DESCRIPTION
flickr API が全て https に移行するらしいので、https でも動くようにしてみました。テスト書くのが難しいので、自分の日記で動作確認を直接しました。

http://code.flickr.net/2014/04/30/flickr-api-going-ssl-only-on-june-27th-2014/
