### PR TITLE
nicovideo: set encoding to data from external API

### DIFF
--- a/plugin/nicovideo.rb
+++ b/plugin/nicovideo.rb
@@ -36,7 +36,12 @@ def nicovideo_call_api( video_id )
 	}
 	status = xml.scan(%r|<nicovideo_thumb_response\s*status="(.*)">|).flatten.first
 	if status == 'ok' then
-		xml.scan(%r|<thumb>(.*)</thumb>|m).flatten.first.scan(%r|<(.*?)>(.*)</.*?>|).to_h
+		raw_api = xml.scan(%r|<thumb>(.*)</thumb>|m).flatten.first.scan(%r|<(.*?)>(.*)</.*?>|)
+		api = {}
+		raw_api.each do |key, value|
+			api[key] = @conf.to_native( value )
+		end
+		api
 	else
 		raise ::Errno::ENOENT::new
 	end


### PR DESCRIPTION
We need to set encoding by ourselves because we stop to use REXML.

Here is a script that reproduces the problem:

```ruby
require 'net/http'
require 'timeout'

def feed?
  false
end

@conf = {}

video_id = "sm9160227"
uri = "http://ext.nicovideo.jp/api/getthumbinfo/#{video_id}"
proxy = @conf['proxy']
proxy = 'http://' + proxy if proxy
xml = timeout( feed? ? 10 : 2 ) {
  px_host, px_port = (@conf['proxy'] || '').split( /:/ )
  px_port = 80 if px_host and !px_port
  Net::HTTP::Proxy( px_host, px_port ).get_response( URI::parse( uri ) ).body
}
status = xml.scan(%r|<nicovideo_thumb_response\s*status="(.*)">|).flatten.first
if status == 'ok' then
  api = xml.scan(%r|<thumb>(.*)</thumb>|m).flatten.first.scan(%r|<(.*?)>(.*)</.*?>|).to_h
else
  raise ::Errno::ENOENT::new
end

require "pp"
pp api
```

It outputs the following:

```
{"video_id"=>"sm9160227",
 "title"=>
  "\xE3\x83\xAC\xE3\x82\xB7\xE3\x83\x94\xE3\x81\xAB\xE6\x9B\xB8\xE3\x81\x8B\xE3\x82\x8C\xE3\x81\xA6\xE3\x81\x84\xE3\x81\xAA\xE3\x81\x84\xE3\x81\x93\xE3\x81\xA8 - \xE9\xA0\x88\xE8\x97\xA4 \xE5\x8A\x9F\xE5\xB9\xB3",
 "description"=>
  "\xE6\x9C\xAD\xE5\xB9\x8CRuby\xE4\xBC\x9A\xE8\xAD\xB002 (2009/12/05)mylist: mylist/16614060time table: http://regional.rubykaigi.org/sapporo02",
 "thumbnail_url"=>"http://tn-skr4.smilevideo.jp/smile?i=9160227",
 "first_retrieve"=>"2009-12-22T11:05:24+09:00",
 "length"=>"20:41",
 "movie_type"=>"flv",
 "size_high"=>"16534388",
 "size_low"=>"16450718",
 "view_counter"=>"151",
 "comment_num"=>"2",
 "mylist_counter"=>"3",
 "last_res_body"=>
  "\xE6\x9C\xAD\xE5\xB9\x8C\xE3\x81\xA7\xE3\x81\x9F\xE3\x81\x84\xE3\x82\x84\xE3\x81\x8D\xE3\x81\xA3\xE3\x81\xA6\xE3\x81\xAA w ",
 "watch_url"=>"http://www.nicovideo.jp/watch/sm9160227",
 "thumb_type"=>"video",
 "embeddable"=>"1",
 "no_live_play"=>"0",
 "tag category=\"1\" lock=\"1\""=>
  "\xE3\x83\x8B\xE3\x82\xB3\xE3\x83\x8B\xE3\x82\xB3\xE5\x8B\x95\xE7\x94\xBB\xE8\xAC\x9B\xE5\xBA\xA7",
 "tag"=>"\xE6\x9C\xAD\xE5\xB9\x8CRuby\xE4\xBC\x9A\xE8\xAD\xB002",
 "user_id"=>"1862988",
 "user_nickname"=>"snoozer05",
 "user_icon_url"=>
  "http://usericon.nimg.jp/usericon/s/186/1862988.jpg?1423463127"}
```

`\xE3` and so on show value encoding is `ASCII-8BIT`.