### PR TITLE
specify spec.files without git command

### DIFF
--- a/tdiary-contrib.gemspec
+++ b/tdiary-contrib.gemspec
@@ -13,7 +13,21 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://www.tdiary.org/"
   spec.license       = "GPL-2 and/or others"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = Dir[
+    'README.md',
+    'README.en.md',
+    'Rakefile',
+    'doc/**/*',
+    'filter/**/*',
+    'io/**/*',
+    'js/**/*',
+    'lib/**/*',
+    'misc/**/*',
+    'plugin/**/*',
+    'spec/**/*',
+    'style/**/*',
+    'util/**/*'
+  ]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
.gemspecにてspec.filesの抽出にgitコマンドを呼び出していたため、gitがない環境では.gemspecが動きませんでした。gitを使わずにファイルを指定することで、gitがない環境でも動くようにします。

tdiary/tdiary-core#364 ではなるべく .gemspec を呼び出さない方法にしましたが、依存関係は Gemfile よりも .gemspec に書く方が良さそうでした。

参考
 * tdiary/tdiary-core#356
 * tdiary/tdiary-core#363
 * tdiary/tdiary-core#364
