### PR TITLE
Google Analytics のトラッキングコードを更新

### DIFF
--- a/plugin/google_analytics.rb
+++ b/plugin/google_analytics.rb
@@ -13,15 +13,14 @@ end
 def google_analytics_insert_code
 	return '' unless @conf['google_analytics.profile']
 	<<-HTML
-	<script type="text/javascript"><!--
-	var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-	document.write(unescape('%3Cscript src="' + gaJsHost + 'google-analytics.com/ga.js" type="text/javascript"%3E%3C/script%3E'));
-	// --></script>
-	<script type="text/javascript"><!--
-	try {
-		var pageTracker = _gat._getTracker("UA-#{h @conf['google_analytics.profile']}");
-		pageTracker._trackPageview();
-	} catch (err) {}
+	<script>
+		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+		ga('create', 'UA-#{@conf['google_analytics.profile']}', 'auto');
+		ga('send', 'pageview');
 	// --></script>
 	HTML
 end

--- a/spec/google_analytics_spec.rb
+++ b/spec/google_analytics_spec.rb
@@ -44,15 +44,14 @@ describe "google_analytics plugin" do
 
 	def expected_html_footer_snippet
 		expected = <<-SCRIPT
-		<script type="text/javascript"><!--
-		var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-		document.write(unescape('%3Cscript src="' + gaJsHost + 'google-analytics.com/ga.js" type="text/javascript"%3E%3C/script%3E'));
-		// --></script>
-		<script type="text/javascript"><!--
-		try {
-			var pageTracker = _gat._getTracker("UA-53836-1");
-			pageTracker._trackPageview();
-		} catch (err) {}
+		<script>
+			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+			})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+			ga('create', 'UA-53836-1', 'auto');
+			ga('send', 'pageview');
 		// --></script>
 		SCRIPT
 		expected.gsub( /^\t/, '' ).chomp


### PR DESCRIPTION
`google_analytics` プラグインが埋め込んでいるトラッキングコードが古いもののようだったので、新しい物に置き換えました。

* [サイトに analytics.js を追加する | ウェブ向けアナリティクス（analytics.js）| Google Developers](https://developers.google.com/analytics/devguides/collection/analyticsjs/?hl=ja)