### PR TITLE
fix #118, integrate plugin for instagram.

### DIFF
--- a/plugin/instagr.rb
+++ b/plugin/instagr.rb
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 #
 # instagr.rb - plugin to insert images on instagr.am
+#              !! integrated into the instagram.rb.
+#              !! Please use the instagram.rb
 #
-# Copyright (C) 2011, tamoot <tamoot+tdiary@gmail.com>
+# Copyright (C) 2011-2015, tamoot <tamoot+tdiary@gmail.com>
 # You can redistribute it and/or modify it under GPL2.
 #
 # usage:
@@ -14,46 +16,13 @@
 #  :medium => 306x306 pixel (default)
 #  :large  => 612x612 pixel
 
-require 'cgi'
-require 'json'
-require 'net/http'
-
 def instagr( short_url, size = :medium)
-	return %Q|<p>Argument is empty.. #{short_url}</p>| if !short_url or short_url.empty?
-	option = option.nil? ? {} : option
-
-	# img size
-	size = size.to_sym if size != :medium
-	maxwidth_data = {:medium => 320, :large => 612}
-	maxwidth = maxwidth_data[ size ] ? maxwidth_data[ size ] : maxwidth_data[:medium]
-
-	# proxy
-	px_host, px_port = (@conf['proxy'] || '').split( /:/ )
-	px_port = 80 if px_host and !px_port
-
-	# query
-	query = "?url=#{CGI::escape(short_url)}&maxwidth=#{maxwidth}"
-
-	begin
-		Net::HTTP.version_1_2
-		res = Net::HTTP::Proxy(px_host, px_port).get('instagram.com', "/api/v1/oembed/#{query}")
-		json_data = JSON::parse( res, &:read )
-		width  = option[:width]  ? option[:width]  : json_data["width"]
-		height = option[:height] ? option[:height] : json_data["height"]
-
-		return <<-INSTAGR_DOM
-			<div class="instagr">
-				<a class="instagr" href="#{h short_url}" title="#{h @conf.to_native(json_data["title"])}">
-					<img src="#{h json_data["thumbnail_url"]}" width="#{h width}" height="#{h height}" alt="#{h @conf.to_native(json_data["title"])}">
-				</a>
-				<p>#{h json_data["author_name"]}'s photo.</p>
-			</div>
-		INSTAGR_DOM
-	rescue
-		return %Q|<p>Failed Open URL.. #{short_url}<br>#{h $!}</p>|
-	end
+   if respond_to?(:instagram)
+      instagram( short_url, size )
+   else
+      return %Q|instagr.rb was integrated into instagram.rb. Please use the instagram.rb|
+   end
 end
-alias :instagram :instagr
 
 
 # Local Variables:

--- a/plugin/instagram.rb
+++ b/plugin/instagram.rb
@@ -1,10 +1,67 @@
+# -*- coding: utf-8 -*-
+#
 # instagram.rb - embed your photo/videos in instagram to a diary
 #
 # Author: Tatsuya Sato
 # License: GPL
+require 'cgi'
+require 'json'
+require 'uri'
+require 'net/http'
+require 'open-uri'
 
-def instagram(code, width=612, height=700)
-  <<-BODY
+
+def instagram(*args)
+   uri = URI::parse(args[0])
+   return instagram_iframe(*args) if uri.scheme.nil?
+   return instagram_serverside(*args)
+end
+
+def instagram_iframe(code, width=612, height=700)
+  return <<-BODY
 <iframe src="//instagram.com/p/#{code}/embed/" width="#{width}" height="#{height}" frameborder="0" scrolling="no" allowtransparency="true"></iframe>
   BODY
 end
+
+def instagram_serverside( short_url, size = :medium)
+   return %Q|<p>Argument is empty.. #{short_url}</p>| if !short_url or short_url.empty?
+   option = option.nil? ? {} : option
+
+   # img size
+   size = size.to_sym if size != :medium
+   maxwidth_data = {:medium => 320, :large => 612}
+   maxwidth = maxwidth_data[ size ] ? maxwidth_data[ size ] : maxwidth_data[:medium]
+
+   # proxy
+   px_host, px_port = (@conf['proxy'] || '').split( /:/ )
+   px_port = 80 if px_host and !px_port
+
+   # query
+   query = "?url=#{CGI::escape(short_url)}&maxwidth=#{maxwidth}"
+
+   begin
+      Net::HTTP.version_1_2
+      res = Net::HTTP::Proxy(px_host, px_port).get('instagram.com', "/api/v1/oembed/#{query}")
+      json_data = JSON::parse( res, &:read )
+      width  = option[:width]  ? option[:width]  : json_data["width"]
+      height = option[:height] ? option[:height] : json_data["height"]
+      return <<-INSTAGR_DOM
+         <div class="instagr">
+            <a class="instagr" href="#{h short_url}" title="#{h @conf.to_native(json_data["title"])}">
+               <img src="#{h json_data["thumbnail_url"]}" width="#{h width}" height="#{h height}" alt="#{h @conf.to_native(json_data["title"])}">
+            </a>
+            <p>#{h json_data["author_name"]}'s photo.</p>
+         </div>
+      INSTAGR_DOM
+   rescue
+      return %Q|<p>Failed Open URL.. #{short_url}<br>#{h $!}</p>|
+   end
+end
+
+# Local Variables:
+# mode: ruby
+# indent-tabs-mode: t
+# tab-width: 3
+# ruby-indent-level: 3
+# End:
+# vim: ts=3


### PR DESCRIPTION
instagram向けプラグインを統合します。

1. instagr.rb向け修正

 * instagr.rb単独での利用は行えず、メッセージを出力
 * instagram.rbを有効にすることで、互換性を保ったinstagram.rb側を実行します
 * instagr.rb利用者が混乱しないように配慮してみましたが、懲りすぎかもしれません。。

2. instagram.rb向け修正

 * instagr.rbの処理と、旧instagram.rbの処理を併記
 * instagr.rb利用時の引数、旧instagram.rb利用時の引数で併記された処理へ分岐させています