### PR TITLE
fix security error on unlink in open-uri

### DIFF
--- a/plugin/ohmsha_estore.rb
+++ b/plugin/ohmsha_estore.rb
@@ -31,7 +31,11 @@ def ohmsha_estore( id, doc = nil )
 		return result
 	end
 
-	html = open("https://estore.ohmsha.co.jp#{domain}/titles/#{id}", &:read)
+	html = ''
+	begin
+		open("https://estore.ohmsha.co.jp/titles/#{id}"){|r|html = r.read}
+	rescue SecurityError # avoid error on unlink
+	end
 	info = JSON.parse(html.scan(%r|<script type='application/ld\+json'>(.*?)</script>|m).flatten[0])
 
 	result = <<-EOS


### PR DESCRIPTION
* $SAFEが1の環境でopen-uriがhttp経由で読み込んだバッファがtempfileで作成され、使用後に削除されるタイミングでエラーになる
* これを無視するパッチ。これはゴミが残るが/tmp配下なので問題ないと判断する