### PR TITLE
add a div tag for responsive

### DIFF
--- a/plugin/youtube.rb
+++ b/plugin/youtube.rb
@@ -10,17 +10,21 @@ def youtube( video_id, size = [425,350] )
 		%Q|<div class="youtube"><a href="//www.youtube.com/watch?v=#{video_id}">YouTube (#{video_id})</a></div>|
 	else
 		<<-TAG
+		<div class="youtube-player-wrapper">
 		<iframe class="youtube-player" type="text/html" width="#{size[0]}" height="#{size[1]}" src="//www.youtube.com/embed/#{video_id}" frameborder="0">
 		</iframe>
+		</div>
 		TAG
 	end
 end
 
 def youtube_custom( video_id, size = [416,337] )
   <<-TAG
+  <div  class="youtube-player-wrapper">
   <object width="#{size[0]}" height="#{size[1]}">
   <param name="movie" value="//www.youtube.com/cp/#{video_id}"></param>
   <embed src="//www.youtube.com/cp/#{video_id}" type="application/x-shockwave-flash" width="#{size[0]}" height="#{size[1]}"></embed>
   </object>
+  </div>
   TAG
 end

--- a/spec/youtube_spec.rb
+++ b/spec/youtube_spec.rb
@@ -5,7 +5,7 @@ describe "youtube plugin" do
 	DUMMY_YOUTUBE_VIDEO_ID = 1234567890
 
   {
-    'Mozilla' => %|\t\t<iframe class="youtube-player" type="text/html" width="425" height="350" src="//www.youtube.com/embed/#{DUMMY_YOUTUBE_VIDEO_ID}" frameborder="0">\n\t\t</iframe>\n|
+    'Mozilla' => %|\t\t<div  class="youtube-player-wrapper">\n\t\t<iframe class="youtube-player" type="text/html" width="425" height="350" src="//www.youtube.com/embed/#{DUMMY_YOUTUBE_VIDEO_ID}" frameborder="0">\n\t\t</div>\n\t\t</iframe>\n|
   }.each do |k,v|
     it 'should render object tag in :user_agent' do
       plugin = fake_plugin(:youtube)


### PR DESCRIPTION
※https://github.com/tdiary/tdiary-contrib/pull/127 のやり直しです。テストでこけていたので。

iframeおよびobjectタグをレスポンシブ対応するためにdivタグでラッピングしたいです。

参考：
http://wazanova.jp/items/1086
http://getbootstrap.com/components/#responsive-embed