### PR TITLE
Use relative url for link to map

### DIFF
--- a/plugin/image_gps.rb
+++ b/plugin/image_gps.rb
@@ -68,14 +68,14 @@ def image( id, alt = 'image', thumbnail = nil, size = nil, place = 'photo' )
   google_maps_api_key = @conf['image_gps.google_maps_api_key']
   google_maps_api_key = '' if google_maps_api_key.nil?
   if (@conf['image_gps.map_link_url'].nil? || @conf['image_gps.map_link_url'].empty?)
-    map_link_url = '"http://maps.google.co.jp/maps?q=#{lat},#{lon}"'
+    map_link_url = '"//maps.google.co.jp/maps?q=#{lat},#{lon}"'
   else
     map_link_url = '"'+@conf['image_gps.map_link_url']+'"'
   end
 
   exif = ExifParser.new("#{@image_dir}/#{image}".untaint) rescue nil
 
-  google = "http://maps.google.co.jp"
+  google = "//maps.google.co.jp"
 
   if exif
     #GPS Info
@@ -103,7 +103,7 @@ def image( id, alt = 'image', thumbnail = nil, size = nil, place = 'photo' )
     }
     unless lat.nil?
       unless google_maps_api_key == ''
-        map_img = %Q["http://maps.googleapis.com/maps/api/staticmap?format=gif&amp;]
+        map_img = %Q["//maps.googleapis.com/maps/api/staticmap?format=gif&amp;]
         map_img += %Q[center=#{lat},#{lon}&amp;zoom=14&amp;size=200x200&amp;markers=#{lat},#{lon}&amp;]
         map_img += %Q[key=#{google_maps_api_key}&amp;sensor=false"]
       end

--- a/plugin/image_gps.rb
+++ b/plugin/image_gps.rb
@@ -75,8 +75,6 @@ def image( id, alt = 'image', thumbnail = nil, size = nil, place = 'photo' )
 
   exif = ExifParser.new("#{@image_dir}/#{image}".untaint) rescue nil
 
-  google = "//maps.google.co.jp"
-
   if exif
     #GPS Info
     begin


### PR DESCRIPTION
デフォルトのリンク先(maps.google.co.jp)とstatic mapのソースをrelative urlにする