### PR TITLE
Fix #148: hatena bookmark button

### DIFF
--- a/js/jquery.socialbutton.js
+++ b/js/jquery.socialbutton.js
@@ -669,6 +669,7 @@ function socialbutton_hatena(target, options, defaults, index, max_index)
 	var attr = merge_attributes({
 		'href': 'https://b.hatena.ne.jp/entry/' + url,
 		'class': 'hatena-bookmark-button',
+		'data-hatena-bookmark-url': 'https://b.hatena.ne.jp/entry/' + url,
 		'data-hatena-bookmark-title': title,
 		'data-hatena-bookmark-layout': layout,
 		'title': 'このエントリーをはてなブックマークに追加'

--- a/js/socialbutton.js
+++ b/js/socialbutton.js
@@ -44,7 +44,7 @@ $(function() {
       return {
         url: url,
         title: title,
-        button: 'standard'
+        button: 'simple-balloon'
       };
     },
 


### PR DESCRIPTION
はてなブックマークボタンに設定されるURLが表示中のページのものになってしまうのを、個々のセクションのものに修正。