### PR TITLE
Change the URL specified in script tag to relative one.

### DIFF
--- a/plugin/google_map.rb
+++ b/plugin/google_map.rb
@@ -58,7 +58,7 @@ end
 
 add_header_proc do
    if /\A(?:latest|day|month|nyear|preview)\z/ =~ @mode
-      %Q|<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=true"></script>\n|
+      %Q|<script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=true"></script>\n|
    end
 end
 


### PR DESCRIPTION
Browsers could not load a script file embedded in diaries with google_map plugin since the plugin inserts script tag whose src attribute has http scheme and it doesn't change according to the scheme of the host. 