### PR TITLE
プレビュープラグインを並べて表示

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -6,7 +6,7 @@
  */
 $(function() {
 
-var previewButton = $('input[name="appendpreview"]');
+var previewButton = $('input[name*="preview"]');
 
 $tDiary.plugin.preview = function() {
   previewButton.prop("disabled", true);
@@ -14,14 +14,10 @@ $tDiary.plugin.preview = function() {
     'update.rb',
     $('form.update').serialize() + "&appendpreview=1",
     function(data) {
-      var beforeOffset = $('div.update').offset();
       $('div.autopagerize_page_element').replaceWith(
         $(data).find('div.autopagerize_page_element')
       )
-      var afterOffset = $('div.update').offset();
-      // 自動更新時にスクロール位置を自動調整してみたがカクカクする
-      // window.scrollTo($(window).scrollLeft(),
-      //   $(window).scrollTop() + afterOffset.top - beforeOffset.top);
+      $('div.day').css('flex', '1 1 480px');
       setTimeout($tDiary.plugin.preview, 10000);
     },
     'html'
@@ -33,9 +29,16 @@ $tDiary.plugin.preview = function() {
 
 if ($('div.autopagerize_page_element').length == 0) {
   $('div.update').before(
-    $('<div class="autopagerize_page_element"></div>')
+    '<div class="day autopagerize_page_element">'
   );
 }
+
+$('<div class="preview-container"></div>')
+  .css('display', 'flex')
+  .css('flex-flow', 'row-reverse wrap')
+  .insertAfter('h1')
+  .append($('div.day'));
+$('div.day').css('flex', '1 1 480px');
 
 // プレビューボタンを押した時もajaxで更新するよう設定
 previewButton.click(
@@ -45,6 +48,6 @@ previewButton.click(
   }
 );
 
-setTimeout($tDiary.plugin.preview, 10000);
+$tDiary.plugin.preview();
 
 });

--- a/js/preview.js
+++ b/js/preview.js
@@ -8,7 +8,7 @@ $(function() {
 
 var previewButton = $('input[name*="preview"]');
 
-$tDiary.plugin.preview = function() {
+$tDiary.plugin.preview.reload = function() {
   previewButton.prop("disabled", true);
   $.post(
     'update.rb',
@@ -16,9 +16,11 @@ $tDiary.plugin.preview = function() {
     function(data) {
       $('div.autopagerize_page_element').replaceWith(
         $(data).find('div.autopagerize_page_element')
-      )
-      $('div.day').css('flex', '1 1 480px');
-      setTimeout($tDiary.plugin.preview, 10000);
+      );
+      $('div.day')
+        .css('flex', "1 1 " + $tDiary.plugin.preview.minWidth / 2 + "px");
+      setTimeout($tDiary.plugin.preview.reload,
+        $tDiary.plugin.preview.interval * 1000);
     },
     'html'
   )
@@ -38,16 +40,17 @@ $('<div class="preview-container"></div>')
   .css('flex-flow', 'row-reverse wrap')
   .insertAfter('h1')
   .append($('div.day'));
-$('div.day').css('flex', '1 1 480px');
+$('div.day')
+  .css('flex', "1 1 " + $tDiary.plugin.preview.minWidth / 2 + "px");
 
 // プレビューボタンを押した時もajaxで更新するよう設定
 previewButton.click(
   function(event) {
     event.preventDefault();
-    $tDiary.plugin.preview();
+    $tDiary.plugin.preview.reload();
   }
 );
 
-$tDiary.plugin.preview();
+$tDiary.plugin.preview.reload();
 
 });

--- a/plugin/en/preview.rb
+++ b/plugin/en/preview.rb
@@ -1,0 +1,5 @@
+@preview_label_conf = 'preview'
+@preview_label_interval = 'refresh interval'
+@preview_label_interval_desc = 'Specify the interval at which to display the preview in seconds.'
+@preview_label_min_width = 'side by side screen width'
+@preview_label_min_width_desc = 'Specifies the width to display the preview screen side-by-side in pixels.'

--- a/plugin/ja/preview.rb
+++ b/plugin/ja/preview.rb
@@ -1,0 +1,5 @@
+@preview_label_conf = '日記のプレビュー'
+@preview_label_interval = '更新間隔 (秒)'
+@preview_label_interval_desc = 'プレビューを表示する間隔を秒単位で指定します。間隔を短くするとよりリアルタイムになりますが、その分サーバーに負荷がかかります。'
+@preview_label_min_width = '横並びで表示する画面サイズ (px)'
+@preview_label_min_width_desc = 'プレビュー画面を横並びで表示する幅をピクセル単位で指定します。ここで指定した幅より画面サイズが小さい場合は縦に並べて表示します。'

--- a/plugin/preview.rb
+++ b/plugin/preview.rb
@@ -12,8 +12,8 @@
 if /\A(form|edit|preview)\z/ === @mode then
 	enable_js('preview.js')
 	add_js_setting('$tDiary.plugin.preview')
-	add_js_setting('$tDiary.plugin.preview.interval', @conf['preview.interval'])
-	add_js_setting('$tDiary.plugin.preview.minWidth', @conf['preview.min_width'])
+	add_js_setting('$tDiary.plugin.preview.interval', @conf['preview.interval'].to_json)
+	add_js_setting('$tDiary.plugin.preview.minWidth', @conf['preview.min_width'].to_json)
 end
 
 add_conf_proc('preview', @preview_label_conf) do

--- a/plugin/preview.rb
+++ b/plugin/preview.rb
@@ -5,6 +5,32 @@
 # Copyright (c) MATSUOKA Kohei <http://www.machu.jp/>
 # Distributed under the GPL2 or any later version.
 #
+
+@conf['preview.interval'] ||= 10
+@conf['preview.min_width'] ||= 960
+
 if /\A(form|edit|preview)\z/ === @mode then
 	enable_js('preview.js')
+	add_js_setting('$tDiary.plugin.preview')
+	add_js_setting('$tDiary.plugin.preview.interval', @conf['preview.interval'])
+	add_js_setting('$tDiary.plugin.preview.minWidth', @conf['preview.min_width'])
+end
+
+add_conf_proc('preview', @preview_label_conf) do
+	if @mode == 'saveconf'
+		@conf['preview.interval'] = @cgi.params['preview.interval'][0].to_i
+		@conf['preview.min_width'] = @cgi.params['preview.min_width'][0].to_i
+	end
+	ERB.new(%q{
+		<h3><%= @preview_label_interval %></h3>
+		<div>
+			<p><%= @preview_label_interval_desc %></p>
+			<p><input name="preview.interval" value="<%=h @conf['preview.interval'] %>"> sec</p>
+		</div>
+		<h3><%= @preview_label_min_width %></h3>
+		<div>
+			<p><%= @preview_label_min_width_desc %></p>
+			<p><input name="preview.min_width" value="<%=h @conf['preview.min_width'] %>"> px</p>
+		</div>
+	}).result(binding)
 end


### PR DESCRIPTION
CSS3のflexboxを使って、プレビュー画面を並べて表示できるようにしました。

 * 960px以上の画面サイズの場合に並べて表示します
 * 960px未満の場合はこれまで通り縦に表示します
 * 左右の比率は1:1です

![preview](https://cloud.githubusercontent.com/assets/9981/15062269/b135fee6-1379-11e6-84e0-2b809c97ae1f.png)
