### PR TITLE
set min width of side by side preview to 896px

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -42,6 +42,7 @@ $('<div class="preview-container"></div>')
   .append($('div.day'));
 $('div.day')
   .css('flex', "1 1 " + $tDiary.plugin.preview.minWidth / 2 + "px");
+$("div.whole-content").css('max-width', 'none');
 
 // プレビューボタンを押した時もajaxで更新するよう設定
 previewButton.click(

--- a/plugin/preview.rb
+++ b/plugin/preview.rb
@@ -7,7 +7,7 @@
 #
 
 @conf['preview.interval'] ||= 10
-@conf['preview.min_width'] ||= 960
+@conf['preview.min_width'] ||= 896
 
 if /\A(form|edit|preview)\z/ === @mode then
 	enable_js('preview.js')


### PR DESCRIPTION
defaultテーマが`max-width 900px`なので、なにも設定変更せずに動作するのが好ましいと思われます。

この900pxは両側に1pxずつ追加のボーダーを含むので、プレビュー画面と合わせて4px分余分に必要なため、previewプラグインで4px分減らしたサイズをmin_widthにします(900 - 4 => 896)。

(もちろん、プレビュー時のみテーマ側のmax widthを大きくするというのもアリです)