### PR TITLE
preview.js: always continue with reloading

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -19,13 +19,13 @@ $tDiary.plugin.preview.reload = function() {
       );
       $('div.day')
         .css('flex', "1 1 " + $tDiary.plugin.preview.minWidth / 2 + "px");
-      setTimeout($tDiary.plugin.preview.reload,
-        $tDiary.plugin.preview.interval * 1000);
     },
     'html'
   )
   .always(function() {
     previewButton.prop("disabled", false);
+    setTimeout($tDiary.plugin.preview.reload,
+      $tDiary.plugin.preview.interval * 1000);
   });
 }
 


### PR DESCRIPTION
プレビュープラグインはサーバから正常にレスポンスが返ってきた場合 (ステータスコード200) のみ自動プレビューを続けるようにしています。しかし、書きかけの日記をプレビューすることで、タイミングが悪いとパースエラーが返ってくることがあり、その結果、自動プレビューが止まってしまいます(#161)。

手動でプレビューボタンを押せば良いのですが、使い勝手が悪いので、エラーが返ってきた場合も自動プレビューを止めないように変更します。
