### PR TITLE
preview.rb: increase the interval time when server returns error

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -7,6 +7,7 @@
 $(function() {
 
 var previewButton = $('input[name*="preview"]');
+var intervalRate = 1;
 
 $tDiary.plugin.preview.reload = function() {
   previewButton.prop("disabled", true);
@@ -22,10 +23,16 @@ $tDiary.plugin.preview.reload = function() {
     },
     'html'
   )
+  .done(function() {
+    intervalRate = 1;
+  })
+  .fail(function() {
+    intervalRate *= 2;
+  })
   .always(function() {
     previewButton.prop("disabled", false);
     setTimeout($tDiary.plugin.preview.reload,
-      $tDiary.plugin.preview.interval * 1000);
+      $tDiary.plugin.preview.interval * 1000 * intervalRate);
   });
 }
 


### PR DESCRIPTION
エラー時はインターバルを伸ばすようにしてみました。とりあえず、1回成功しただけで戻すようにしています。

> これ、同じ問題を感じていて、エラーになったときはサーバが混み合っているときだから、インターバルを倍に伸ばして続けるとか(それでもエラーになったらさらに倍)、一定回数成功したらインターバルを元に戻すとか、そういうのはどうかなと考えていました。ちょっと複雑すぎるかも知れないけど、Heroku free planで運用してるとけっこう頻繁にエラーになるので。

https://github.com/tdiary/tdiary-contrib/pull/162#issuecomment-219930441
