### PR TITLE
fix #161: refresh the preview element except plugin error

### DIFF
--- a/js/preview.js
+++ b/js/preview.js
@@ -15,9 +15,10 @@ $tDiary.plugin.preview.reload = function() {
     'update.rb',
     $('form.update').serialize() + "&appendpreview=1",
     function(data) {
-      $('div.autopagerize_page_element').replaceWith(
-        $(data).find('div.autopagerize_page_element')
-      );
+      var previewContent = $(data).find('div.autopagerize_page_element');
+      if (previewContent.size() != 0) {
+        $('div.autopagerize_page_element').replaceWith(previewContent);
+      }
       $('div.day')
         .css('flex', "1 1 " + $tDiary.plugin.preview.minWidth / 2 + "px");
     },

--- a/js/preview.js
+++ b/js/preview.js
@@ -18,17 +18,21 @@ $tDiary.plugin.preview.reload = function() {
       var previewContent = $(data).find('div.autopagerize_page_element');
       if (previewContent.size() != 0) {
         $('div.autopagerize_page_element').replaceWith(previewContent);
+        intervalRate = 1;
+      } else {
+        intervalRate *= 2;
+        console.info('[preview.js] update failed, the next update will be after '
+          + $tDiary.plugin.preview.interval * intervalRate + 'sec.');
       }
       $('div.day')
         .css('flex', "1 1 " + $tDiary.plugin.preview.minWidth / 2 + "px");
     },
     'html'
   )
-  .done(function() {
-    intervalRate = 1;
-  })
   .fail(function() {
     intervalRate *= 2;
+    console.info('[preview.js] update failed, the next update will be after '
+      + $tDiary.plugin.preview.interval * intervalRate + 'sec.');
   })
   .always(function() {
     previewButton.prop("disabled", false);


### PR DESCRIPTION
プラグインエラーが発生したときにプレビュー画面が消えてしまうバグを解消しました。サーバーから返されたHTMLに `div.autopagerize_page_element` 要素が含まれているときだけ、プレビュー領域を書き換えるようにしています。