### PR TITLE
update jQuery to 3.0

### DIFF
--- a/js/appstore.js
+++ b/js/appstore.js
@@ -88,7 +88,7 @@ $( function() {
 	};
 
 	// for AutoPagerize
-	$(window).bind('AutoPagerize_DOMNodeInserted', function(event) {
+	$(window).on('AutoPagerize_DOMNodeInserted', function(event) {
 		appstore(event.target);
 	});
 	

--- a/js/image_ex.js
+++ b/js/image_ex.js
@@ -64,13 +64,13 @@ $(function() {
 
 	if ($(window).width() <= 360) {
 		$(document).ready(function() {
-			$("img.image-ex").bind("load", function() {
+			$("img.image-ex").on("load", function() {
 				resizeImage(this);
 			});
 		});
 
 		// for when images have been cached
-		$(window).bind("load", function() {
+		$(window).on("load", function() {
 			$("img.image-ex").each(function() {
 				resizeImage(this);
 			});

--- a/js/jquery.socialbutton.js
+++ b/js/jquery.socialbutton.js
@@ -293,7 +293,7 @@ $.fn.socialbutton = function(service, options) {
 		}
 	};
 
-	var max_index = this.size() - 1;
+	var max_index = this.length - 1;
 
 	return this.each(function(index) {
 

--- a/js/show_and_hide.js
+++ b/js/show_and_hide.js
@@ -16,7 +16,7 @@ $( function() {
 	};
 	
 	// for AutoPagerize
-	$(window).bind('AutoPagerize_DOMNodeInserted', function(event) {
+	$(window).on('AutoPagerize_DOMNodeInserted', function(event) {
 		show_and_hide(event.target);
 	});
 	

--- a/js/socialbutton.js
+++ b/js/socialbutton.js
@@ -129,7 +129,7 @@ $(function() {
     });
   }
 
-  $(window).bind('scroll', function(event) {
+  $(window).on('scroll', function(event) {
     socialbutton(document);
   });
 

--- a/js/socialbutton.js
+++ b/js/socialbutton.js
@@ -92,7 +92,7 @@ $(function() {
         return bottom > $(this).offset().top;
       })
       .filter(function() {
-        return $(this).find('.socialbutton').size() == 0
+        return $(this).find('.socialbutton').length == 0
       })
       .each(function() {
         var anchor = $(this).find('h3 a');
@@ -100,7 +100,7 @@ $(function() {
           var link = $(this).children('h2').find('a:first').get(0);
           var url = link ? link.href : document.URL;
           var title = $(this).children('h2').find('.title').text();
-        } else if (anchor.size() == 0) {
+        } else if (anchor.length == 0) {
           // The section may not have an anchor on etdiary style.
           // https://github.com/tdiary/tdiary-contrib/issues/59
           var url = ($(this).parents('.day').find('h2 a:first').get(0)||'').href;


### PR DESCRIPTION
coreでjQuery 3.0にするのに合わせ、jQuery 3.0で削除された(ないしは削除予定の)関数を置き換えるなどの修正を行っています。