### PR TITLE
Googleフォトプラグイン

### DIFF
--- a/js/google_photos.js
+++ b/js/google_photos.js
@@ -1,0 +1,63 @@
+$(function() {
+  var developerKey = $tDiary.plugin.google_photos.api_key;
+  var clientId = $tDiary.plugin.google_photos.client_id;
+  var oauthToken;
+
+  if (!developerKey || !clientId) {
+    $('#google_photos').after($('<p>設定画面でAPIキーとクライアントIDを登録してください</p>'));
+    return false;
+  }
+
+  gapi.load('auth',
+    { callback: function() { console.debug('load auth function') } });
+  gapi.load('picker',
+    { callback: function() { console.debug('load picker function') } });
+
+  $('#google_photos').click(function() {
+    if (oauthToken) {
+      createPicker();
+    } else {
+      authentication();
+    }
+  });
+
+  function authentication() {
+    window.gapi.auth.authorize(
+    {
+      'client_id': clientId,
+      'scope': ['https://www.googleapis.com/auth/photos'],
+      'immediate': false
+    },
+    function(authResult) {
+      if (!authResult || authResult.error) {
+        console.error('[google_photos] authentication faild');
+        return false;
+      }
+      oauthToken = authResult.access_token;
+      createPicker();
+    });
+  }
+
+  function createPicker() {
+    var picker = new google.picker.PickerBuilder()
+      .addView(new google.picker.PhotosView()
+        .setType(google.picker.PhotosView.Type.UPLOADED))
+      .addView(google.picker.ViewId.PHOTOS)
+      .addView(google.picker.ViewId.PHOTO_UPLOAD)
+      .setOAuthToken(oauthToken)
+      .setDeveloperKey(developerKey)
+      .setLocale('ja')
+      .setCallback(pickerCallback)
+      .build();
+    picker.setVisible(true);
+  }
+
+  function pickerCallback(data) {
+    if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
+      var doc = data[google.picker.Response.DOCUMENTS][0];
+      var image = doc.thumbnails[doc.thumbnails.length - 1];
+      var tag = $.makePluginTag("google_photos '" + image.url + "', '" + image.width + "', '" + image.height + "'");
+      $('#body').insertAtCaret(tag);
+    }
+  }
+});

--- a/plugin/google_photos.rb
+++ b/plugin/google_photos.rb
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# show Google Photos
+#
+# Copyright (c) MATSUOKA Kohei <http://www.machu.jp/>
+# Distributed under the GPL
+#
+
+@conf['google_photos.api_key'] = nil
+@conf['google_photos.client_id'] = nil
+@conf['google_photos.api_key'] ||= 'AIzaSyCJIwIQMND58yVOZ8oeemCcMXYl6YU0jMQ'
+@conf['google_photos.client_id'] ||= '797614784971-a0lhq52knkcgber5imvfn8gcgf904tks.apps.googleusercontent.com'
+
+def google_photos(src, width, height, alt="photo", place="photo")
+	%Q|<img title="#{alt}" width="#{width}" height="#{height}" alt="#{alt}" src="#{src}" class="#{place} google">|
+end
+
+def google_photos_left(src, width, height, alt="photo")
+	google_photos(src, width, height, alt, 'left')
+end
+
+def google_photos_right(src, width, height, alt="photo")
+	google_photos(src, width, height, alt, 'right')
+end
+
+if /\A(form|edit|preview|showcomment)\z/ === @mode then
+  enable_js('google_photos.js')
+  add_js_setting('$tDiary.plugin.google_photos')
+  add_js_setting('$tDiary.plugin.google_photos.api_key', @conf['google_photos.api_key'].to_json)
+  add_js_setting('$tDiary.plugin.google_photos.client_id', @conf['google_photos.client_id'].to_json)
+
+  add_footer_proc do
+    '<script type="text/javascript" src="https://apis.google.com/js/api.js?onload=onApiLoad"></script>'
+  end
+end
+
+add_edit_proc do |date|
+  <<-FORM
+	<div class="google_photos">
+		<input id="google_photos" type="button" value="Googleフォト"></input>
+	</div>
+  FORM
+end
+
+add_conf_proc('google_photos', 'Googleフォト') do
+  if @mode == 'saveconf'
+    @conf['google_photos.api_key'] = @cgi.params['google_photos.api_key'][0]
+    @conf['google_photos.client_id'] = @cgi.params['google_photos.client_id'][0]
+  end
+
+  r = <<-_HTML
+  <h3>APIキー</h3>
+  <p><input type="text" name="google_photos.api_key" size="100" value="#{@conf['google_photos.api_key']}"></p>
+  <h3>認証用クライアントID</h3>
+  <p><input type="text" name="google_photos.client_id" size="100" value="#{@conf['google_photos.client_id']}"></p>
+_HTML
+end


### PR DESCRIPTION
Picasaのサービス終了に伴いPicasaプラグインが表示専用になっていたので、代わりにGoogleフォトプラグインを作りました。

機能
 * Google Picker APIを使ってGoogleフォトの写真を選択
 * Googleフォトへの写真のアップロードも可能

制約
 * サムネイルを使用しているため、サイズが512pxまでしか表示できない
 * プラグインを使うためには、Google DevelopersのサイトでAPIキーの登録が必要（ちょっと面倒）

参考
 * https://developers.google.com/picker/docs/
 * https://console.developers.google.com/apis/
 * http://qiita.com/howdy39/items/a7de282e6dd5350f7a7c
 * http://hr-sano.net/google-photos-embed-code-generator/

![2017-05-24 8 37 47](https://cloud.githubusercontent.com/assets/9981/26380921/4b889084-405c-11e7-8a71-6aae838cd828.png)
