### PR TITLE
Support latest version of the Google code-prettify

### DIFF
--- a/plugin/prettify.rb
+++ b/plugin/prettify.rb
@@ -3,15 +3,21 @@
 if /\A(?:latest|day|month|nyear)\z/ =~ @mode then
 	add_header_proc do
 		<<-HTML
-		<link href="https://google-code-prettify.googlecode.com/svn/trunk/src/prettify.css" type="text/css" rel="stylesheet">
-		<script type="text/javascript" src="https://google-code-prettify.googlecode.com/svn/trunk/src/prettify.js"></script>
+		<script type="text/javascript" src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
 		<script type="text/javascript"><!--
+			var initPrettyPrint = function() {
+				var pres = document.querySelectorAll("div.body > div.section > pre");
+				Array.prototype.slice.call(pres).forEach(function(pre) {
+					pre.setAttribute("class", "prettyprint");
+				});
+				PR.prettyPrint();
+			};
 			if(window.addEventListener){
-				window.addEventListener("load", prettyPrint, false);
+				window.addEventListener("load", initPrettyPrint, false);
 			}else if(window.attachEvent){
-				window.attachEvent("onload", prettyPrint);
+				window.attachEvent("onload", initPrettyPrint);
 			}else{
-				window.onload=prettyPrint;
+				window.onload=initPrettyPrint;
 			}
 		// --></script>
 		HTML


### PR DESCRIPTION
最新の[Google code-prettify](https://github.com/google/code-prettify)で仕様が変わり、これを利用するプラグインが動作しなくなっていたのを修正しました。

* code-prettifyを読み込むCDNのURLを、サービス終了したGoogle Code `google-code-prettify.googlecode.com` から `cdn.rawgit.com/google/code-prettify` に変更
    * CSSファイルもrun_prettify.jsから一緒に読み込まれるようになったのでlink要素を削除
* 構文ハイライトする関数に `PR.prettyPrint` と名前空間オブジェクトが追加されていたので対応
* pre要素にclass "prettyprint" が付与されていないと動作しないため、付与する処理を追加
    * 過去のコミット 5cf34110ba2b8e1989d5673bd3bb3c368a25b2bf で同様の処理が消されているようです（ちょっと過去の経緯までは読み取れなかったため、必要と判断して処理を入れています）

プラグイン修正前後の動作は以下のキャプチャ通りです。

修正前：
![pretty rb_before](https://cloud.githubusercontent.com/assets/221802/26686697/ba0ebfba-4728-11e7-9705-1e9b49c1e328.png)

修正後：
![pretty rb_after](https://cloud.githubusercontent.com/assets/221802/26686702/bee86dc4-4728-11e7-8d9c-49b32922911d.png)
