### PR TITLE
MathJax プラグインの参照先アドレスの修正

### DIFF
--- a/plugin/mathjax.rb
+++ b/plugin/mathjax.rb
@@ -10,14 +10,21 @@
 # Copyright (C) 2014 by Yuh Ohmura <http://yutopia.pussycat.jp/diary/>
 #
 =begin ChangeLog
+2017-06-05 Yuh Ohmura
+    * Modity MathJax address.
 2014-12-17 Yuh Ohmura
 	* created.
 =end
 add_header_proc do
 '<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({tex2jax: {inlineMath: [[\'$\',\'$\'], ["\\\\(","\\\\)"]]}});
+  MathJax.Hub.Config({
+    tex2jax: {
+       inlineMath: [[\'$\',\'$\'], ["\\\\(","\\\\)"]],
+       processEscapes: true
+    }
+  }
+);
 </script>
-<script type="text/javascript"
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+<script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_CHTML">
 </script>'
 end


### PR DESCRIPTION
MathJax の古い参照先のアドレスが廃止されて別のアドレスとなったので対応しました。