### PR TITLE
fix error on tatsu_zine site update and https

### DIFF
--- a/plugin/tatsu_zine.rb
+++ b/plugin/tatsu_zine.rb
@@ -32,12 +32,12 @@ def tatsu_zine( id, doc = nil )
 		return result
 	end
 
-	link = "http://tatsu-zine.com/books/#{id}"
+	link = "https://tatsu-zine.com/books/#{id}"
 	doc ||= open( link ).read
 	title = doc.match(%r|<meta property="og:title" content="(.*)">|).to_a[1]
 	image = doc.match(%r|<meta property="og:image" content="(.*)">|).to_a[1]
-	price = doc.match(%r|<meta name="twitter:data2" content="(.*)JPY">|).to_a[1]
-	author = doc.match(%r|<meta name="twitter:data1" content="(.*)">|).to_a[1]
+	price = doc.match(%r|span itemprop="price">(.*)</span>|).to_a[1]
+	author = doc.match(%r|<p itemprop="author" class="author">(.*)</p>|).to_a[1]
 
 	result = <<-EOS
 	<a class="amazon-detail" href="#{h link}"><span class="amazon-detail">
@@ -54,7 +54,8 @@ EOS
 
 	tatsu_zine_cache_set( id, result ) unless @conf.secure
 	result
-rescue
+rescue => e
+	@logger.error(e)
 	link
 end
 

--- a/plugin/tatsu_zine.rb
+++ b/plugin/tatsu_zine.rb
@@ -33,7 +33,7 @@ def tatsu_zine( id, doc = nil )
 	end
 
 	link = "https://tatsu-zine.com/books/#{id}"
-	doc ||= open( link ).read
+	doc ||= open(link, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE).read
 	title = doc.match(%r|<meta property="og:title" content="(.*)">|).to_a[1]
 	image = doc.match(%r|<meta property="og:image" content="(.*)">|).to_a[1]
 	price = doc.match(%r|span itemprop="price">(.*)</span>|).to_a[1]


### PR DESCRIPTION
達人出版会のサイトがhttps化するとともにページの構造が変わってエラーになっていたものを修正。
https化にともない、一部のrubyバージョンでverifyエラーになっていたので、一時的に無視するワークアラウンドも追加。