### PR TITLE
fix error on the ogp plugin on an empty day

### DIFF
--- a/plugin/ogp.rb
+++ b/plugin/ogp.rb
@@ -39,7 +39,7 @@ def ogp_tag
 		if diary
 			sections = diary.instance_variable_get(:@sections)
 			section_index = @cgi.params['p'][0] || sections.size
-			section = sections[section_index.to_i - 1].body_to_html
+			section = sections[section_index.to_i - 1]&.body_to_html
 			section_html = apply_plugin(section)
 
 			headers['og:description'] = ogp_description(section_html)

--- a/plugin/ogp.rb
+++ b/plugin/ogp.rb
@@ -39,7 +39,7 @@ def ogp_tag
 		if diary
 			sections = diary.instance_variable_get(:@sections)
 			section_index = @cgi.params['p'][0] || sections.size
-			section = sections[section_index.to_i - 1]&.body_to_html
+			section = sections[section_index.to_i - 1].body_to_html if sections[section_index.to_i - 1]
 			section_html = apply_plugin(section)
 
 			headers['og:description'] = ogp_description(section_html)

--- a/plugin/ogp.rb
+++ b/plugin/ogp.rb
@@ -39,11 +39,14 @@ def ogp_tag
 		if diary
 			sections = diary.instance_variable_get(:@sections)
 			section_index = @cgi.params['p'][0] || sections.size
-			section = sections[section_index.to_i - 1].body_to_html if sections[section_index.to_i - 1]
-			section_html = apply_plugin(section)
+            begin
+				section = sections[section_index.to_i - 1].body_to_html
+				section_html = apply_plugin(section)
 
-			headers['og:description'] = ogp_description(section_html)
-			headers['og:image'] = ogp_image(section_html)
+				headers['og:description'] = ogp_description(section_html)
+				headers['og:image'] = ogp_image(section_html)
+            rescue
+            end
 		end
 	end
 


### PR DESCRIPTION
日記にセクションが全くないときに、その日にアクセスすると
ogp.rb の 42 行目 (https://github.com/tdiary/tdiary-contrib/blob/fix/ogp-empty-section/plugin/ogp.rb#L42) で nil になって .body_to_html できないエラーがでていたのを修正しました。
ただ、ぼっちオペレータはまだ使ってはいけないでしょうか。別の方法で書き直した方がよければお教え願いたく存じます。