### PR TITLE
fix #179 : add English resource of profile plugin

### DIFF
--- a/plugin/en/profile.rb
+++ b/plugin/en/profile.rb
@@ -1,0 +1,13 @@
+#
+# profile.rb: english resource of profile plugin for tDiary
+#
+# Copyright (C) 2017 by Tada, Tadashi <t@tdtds.jp>
+# Distributed under the GPL.
+#
+module ::Profile
+	module Service
+		class Gravatar < Base
+			HOST = 'en.gravatar.com'
+		end
+	end
+end

--- a/plugin/profile.rb
+++ b/plugin/profile.rb
@@ -113,9 +113,11 @@ module ::Profile
 
 		# gravatar.com
 		class Gravatar < Base
+			HOST = 'ja.gravatar.com' unless const_defined?(:HOST)
+			p "japanese: #{HOST}"
 			endpoint {|id|
 				hash = Digest::MD5.hexdigest(id.downcase)
-				"https://www.gravatar.com/#{hash}.json"
+				"https://#{HOST}/#{hash}.json"
 			}
 
 			def image
@@ -124,6 +126,7 @@ module ::Profile
 			end
 
 			def fetch(endpoint)
+				p endpoint
 				require 'json'
 				Timeout.timeout(5) do
 					begin

--- a/plugin/profile.rb
+++ b/plugin/profile.rb
@@ -114,7 +114,6 @@ module ::Profile
 		# gravatar.com
 		class Gravatar < Base
 			HOST = 'ja.gravatar.com' unless const_defined?(:HOST)
-			p "japanese: #{HOST}"
 			endpoint {|id|
 				hash = Digest::MD5.hexdigest(id.downcase)
 				"https://#{HOST}/#{hash}.json"
@@ -126,7 +125,6 @@ module ::Profile
 			end
 
 			def fetch(endpoint)
-				p endpoint
 				require 'json'
 				Timeout.timeout(5) do
 					begin


### PR DESCRIPTION
GravatarのAPIはリクエストの言語に応じて異なるendpointのURLへリダイレクトする(日本語ならja.〜、英語ならen.〜)。このため、プラグインもtDiaryの言語設定に応じてリダイレクト先を使うように変更した。

なお、ブラウザの言語指定を使うべきという議論もあるだろうが、どのような言語指定が来るかもわからないため、とりあえずtDiary側の指定を使った。