### PR TITLE
add resize option for Google photos

### DIFF
--- a/js/google_photos.js
+++ b/js/google_photos.js
@@ -48,16 +48,20 @@ $(function() {
       .setDeveloperKey(developerKey)
       .setLocale('ja')
       .setCallback(pickerCallback)
+      .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)
       .build();
     picker.setVisible(true);
   }
 
   function pickerCallback(data) {
     if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
-      var doc = data[google.picker.Response.DOCUMENTS][0];
-      var image = doc.thumbnails[doc.thumbnails.length - 1];
-      var tag = $.makePluginTag("google_photos '" + image.url + "', '" + image.width + "', '" + image.height + "'");
-      $('#body').insertAtCaret(tag);
+      var tag = [];
+      for (var i = 0; i < data[google.picker.Response.DOCUMENTS].length; i++) {
+        var doc = data[google.picker.Response.DOCUMENTS][i];
+        var image = doc.thumbnails[doc.thumbnails.length - 1];
+        tag.push($.makePluginTag("google_photos '" + image.url + "', '" + image.width + "', '" + image.height + "'"));
+      }
+      $('#body').insertAtCaret(tag.join("\n") + "\n");
     }
   }
 });

--- a/plugin/google_photos.rb
+++ b/plugin/google_photos.rb
@@ -5,15 +5,21 @@
 # Distributed under the GPL
 #
 
-def google_photos(src, width, height, alt="photo", place="photo")
+def google_photos(src, width, height, scale=70, alt="photo", place="photo")
+	width = width.to_i * (scale.to_f / 100)
+	height = height.to_i * (scale.to_f / 100)
 	%Q|<img title="#{alt}" width="#{width}" height="#{height}" alt="#{alt}" src="#{src}" class="#{place} google">|
 end
 
-def google_photos_left(src, width, height, alt="photo")
+def google_photos_left(src, width, height, scale=70, alt="photo")
+	width = width.to_i * (scale.to_f / 100)
+	height = height.to_i * (scale.to_f / 100)
 	google_photos(src, width, height, alt, 'left')
 end
 
-def google_photos_right(src, width, height, alt="photo")
+def google_photos_right(src, width, height, scale=70, alt="photo")
+	width = width.to_i * (scale.to_f / 100)
+	height = height.to_i * (scale.to_f / 100)
 	google_photos(src, width, height, alt, 'right')
 end
 

--- a/plugin/google_photos.rb
+++ b/plugin/google_photos.rb
@@ -5,19 +5,22 @@
 # Distributed under the GPL
 #
 
-def google_photos(src, width, height, scale=70, alt="photo", place="photo")
+def google_photos(src, width, height, alt="photo", place="photo", scale=nil)
+	scale = scale || @conf['google_photos.scale'] || 100
 	width = width.to_i * (scale.to_f / 100)
 	height = height.to_i * (scale.to_f / 100)
 	%Q|<img title="#{alt}" width="#{width}" height="#{height}" alt="#{alt}" src="#{src}" class="#{place} google">|
 end
 
-def google_photos_left(src, width, height, scale=70, alt="photo")
+def google_photos_left(src, width, height, alt="photo", scale=nil)
+	scale = scale || @conf['google_photos.scale'] || 100
 	width = width.to_i * (scale.to_f / 100)
 	height = height.to_i * (scale.to_f / 100)
 	google_photos(src, width, height, alt, 'left')
 end
 
-def google_photos_right(src, width, height, scale=70, alt="photo")
+def google_photos_right(src, width, height, alt="photo", scale=nil)
+	scale = scale || @conf['google_photos.scale'] || 100
 	width = width.to_i * (scale.to_f / 100)
 	height = height.to_i * (scale.to_f / 100)
 	google_photos(src, width, height, alt, 'right')
@@ -46,6 +49,8 @@ add_conf_proc('google_photos', 'Googleフォト') do
   if @mode == 'saveconf'
     @conf['google_photos.api_key'] = @cgi.params['google_photos.api_key'][0]
     @conf['google_photos.client_id'] = @cgi.params['google_photos.client_id'][0]
+    @conf['google_photos.scale'] = @cgi.params['google_photos.scale'][0]
+    @conf['google_photos.scale'] = 100 if @conf['google_photos.scale'].nil? || @conf['google_photos.scale'].empty?
   end
 
   r = <<-_HTML
@@ -69,5 +74,7 @@ add_conf_proc('google_photos', 'Googleフォト') do
 	<p><input type="text" name="google_photos.api_key" size="100" value="#{@conf['google_photos.api_key']}"></p>
 	<h3>認証用クライアントID</h3>
 	<p><input type="text" name="google_photos.client_id" size="100" value="#{@conf['google_photos.client_id']}"></p>
+	<h3>サムネイルからの縮小率 (単位%。数値1〜100)</h3>
+	<p><input type="text" name="google_photos.scale" size="100" value="#{@conf['google_photos.scale']}"></p>
 _HTML
 end


### PR DESCRIPTION
Google Photosプラグインにおいて、
Googleプレビューのサイズをそのまま使うのはちょっと大きすぎるように感じています。

CSSでは縦横写真が混在しているときに対処できないので、拡縮パーセンテージのオプションを取るようにしてみました。

以下の2点があるので、現在Photosプラグインを使用されている方のご意見を伺いたいです。

* 自分の経験ではこのパッチで適用している70%くらいがちょうどよいと思うけれども、人によって評価は割れそう。設定パラメータにできるとよいのだが…
* 引数が増えたので、既存の記事でaltやplaceを指定していたような場合は壊れることになる。おとなしく末尾に置いたほうがいいだろうか