### PR TITLE
specify integer size in google_photos

### DIFF
--- a/plugin/google_photos.rb
+++ b/plugin/google_photos.rb
@@ -9,7 +9,7 @@ def google_photos(src, width, height, alt="photo", place="photo", scale=nil)
 	scale = scale || @conf['google_photos.scale'] || 100
 	width = width.to_i * (scale.to_f / 100)
 	height = height.to_i * (scale.to_f / 100)
-	%Q|<img title="#{alt}" width="#{width}" height="#{height}" alt="#{alt}" src="#{src}" class="#{place} google">|
+	%Q|<img title="#{alt}" width="#{width.to_i}" height="#{height.to_i}" alt="#{alt}" src="#{src}" class="#{place} google">|
 end
 
 def google_photos_left(src, width, height, alt="photo", scale=nil)


### PR DESCRIPTION
img要素のサイズ指定は整数であるべきところ、スケールの計算結果が浮動小数点数なので文法エラーになっています。とりあえず`to_i`で切り捨てましたが、四捨五入等の適切な丸めが必要かも?