### PR TITLE
change twitpic plugin's embed images to links

### DIFF
--- a/plugin/twitpic.rb
+++ b/plugin/twitpic.rb
@@ -5,6 +5,6 @@
 # You can redistribute it and/or modify it under GPL2.
 #
 
-def twitpic( image_id, label = 'image on Twitpic', place = 'photo' )
-	%Q|<a class="twitpic" href="http://twitpic.com/#{h image_id}" title="#{h label}"><img class="#{h place}" src="http://twitpic.com/show/thumb/#{h image_id}.jpg" width="150" height="150" alt="#{h label}"></a>|
+def twitpic(image_id, label = 'Image on Twitpic', place = 'photo')
+	%Q|<p><a class="twitpic" href="http://twitpic.com/#{h image_id}">#{h label}</a></p>|
 end


### PR DESCRIPTION
* TwitpicはTwitterに買収されてサービスを終了したが、アーカイブのみ残された
* ただしサムネイル機能などは廃止されたため埋め込みイメージが使えなくなった
* iframeで元のプラグイン動作を再現しようとも考えたがわりと無駄な努力っぽいのでリンクに置き換えた