### PR TITLE
Fix issue #211, Orientation information is not reflected.

### DIFF
--- a/plugin/image_ex.rb
+++ b/plugin/image_ex.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # image_plugin_ex.rb
 # version 0.3
 # -pv-
@@ -199,7 +200,7 @@ add_form_proc do |date|
 					imageex_convertedsize = %Q[#{imageex_convertedheight}x#{imageex_convertedwidth}]
 					imageex_convertedsize
 				end
-				system(imageex_convertpath , "-geometry", imageex_convertedsize , orig, new)
+				system(imageex_convertpath , "-auto-orient", "-geometry", imageex_convertedsize , orig, new)
 				if FileTest::size?( new ) == 0
 					File::delete( new )
 				end


### PR DESCRIPTION
* Issue #211の問題を修正するパッチです。
* convertコマンドのオプション '-auto-orient' を使っています

* なお、tdiary-core v5.0.14では、image_ex.rb がエラーになってしまうようです。v5.0.13で確認しました