### PR TITLE
follow new callback plugin style from  5.0.14

### DIFF
--- a/plugin/hb_footer.rb
+++ b/plugin/hb_footer.rb
@@ -8,7 +8,7 @@
 # Author: ishinao <ishinao@ishinao.net>
 #
 
-add_body_leave_proc(Proc.new do |date|
+add_body_leave_proc do |date|
   if @mode == 'day' or @mode == 'latest'
     diary = @diaries[date.strftime('%Y%m%d')]
     pnum = 1
@@ -33,7 +33,7 @@ add_body_leave_proc(Proc.new do |date|
   else
     ''
   end
-end)
+end
 
 # rss-recent.rb: RSS recent plugin
 #

--- a/plugin/image_ex.rb
+++ b/plugin/image_ex.rb
@@ -86,11 +86,11 @@
 
 enable_js("image_ex.js")
 
-add_body_enter_proc(Proc.new do |date|
+add_body_enter_proc do |date|
 	@image_date = date.strftime("%Y%m%d")
 	@image_year = date.strftime("%Y")
 	""
-end)
+end
 
 
 def image( id, alt = "image", id2 = nil, width = nil, place="none" )

--- a/plugin/mm_footer.rb
+++ b/plugin/mm_footer.rb
@@ -9,7 +9,7 @@
 
 require 'nkf'
 
-add_body_leave_proc(Proc.new do |date|
+add_body_leave_proc do |date|
 
   oldest_date = Time.local(2005, 1, 11)
   if date > oldest_date
@@ -38,7 +38,7 @@ add_body_leave_proc(Proc.new do |date|
 		''
 	 end
   end
-end)
+end
 
 require "rss/rss"
 

--- a/plugin/socialbutton.rb
+++ b/plugin/socialbutton.rb
@@ -52,9 +52,9 @@ end
 if @mode =~ /^(latest|day|month|nyear)$/
 	socialbutton_footer = Proc.new { %Q|<div class="socialbuttons"></div>| }
 	if respond_to?(:blogkit?) && blogkit?
-		add_body_leave_proc(socialbutton_footer)
+		add_body_leave_proc(&socialbutton_footer)
 	else
-		add_section_leave_proc(socialbutton_footer)
+		add_section_leave_proc(&socialbutton_footer)
 	end
 
 	# load javascript

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,19 +49,19 @@ class PluginFake
 		@conf_procs << block
 	end
 
-	def add_edit_proc( block = Proc::new )
+	def add_edit_proc(&block)
 		@edit_procs << block
 	end
 
-	def add_header_proc( block = Proc::new )
+	def add_header_proc(&block)
 		@header_procs << block
 	end
 
-	def add_footer_proc( block = Proc::new )
+	def add_footer_proc(&block)
 		@footer_procs << block
 	end
 
-	def add_update_proc( block = Proc::new )
+	def add_update_proc(&block)
 		@update_procs << block
 	end
 
@@ -89,7 +89,7 @@ class PluginFake
 		r.join.chomp
 	end
 
-	def add_body_enter_proc( block = Proc::new )
+	def add_body_enter_proc(&block)
 		@body_enter_procs << block
 	end
 
@@ -101,7 +101,7 @@ class PluginFake
 		r.join.chomp
 	end
 
-	def add_body_leave_proc( block = Proc::new )
+	def add_body_leave_proc(&block)
 		@body_leave_procs << block
 	end
 

--- a/util/image-gallery/misc/plugin/recent_image.rb
+++ b/util/image-gallery/misc/plugin/recent_image.rb
@@ -259,10 +259,10 @@ end
 #  Callback Functions
 
 # this is for view_exif().
-add_body_enter_proc(Proc.new do |date|
+add_body_enter_proc do |date|
   @image_date_exif = date.strftime("%Y%m%d")
   ""
-end)
+end
 
 #  Update Proc of the plugin
 add_update_proc do

--- a/util/image-gallery/misc/plugin/view_exif.rb
+++ b/util/image-gallery/misc/plugin/view_exif.rb
@@ -49,7 +49,7 @@ end
 
 #  Callback Functions
 
-add_body_enter_proc(Proc.new do |date| 
+add_body_enter_proc do |date| 
   @image_date_exif = date.strftime("%Y%m%d")
   ""
-end)
+end


### PR DESCRIPTION
tDiary 5.0.14からcallback系プラグインの呼び出しでblockパラメタを必須にした影響で呼び出されなくなっていたプラグイン(とテスト)を修正。