### PR TITLE
Twitter Timeline のURLがhttpsへ統一されたのでそれに合わせる

### DIFF
--- a/plugin/twitter.rb
+++ b/plugin/twitter.rb
@@ -14,7 +14,7 @@ if /^(latest|day)$/ =~ @mode then
 		xml = nil
 		Timeout.timeout( 5 ) do
 			begin
-				xml = open( "http://twitter.com/statuses/user_timeline/#{@conf['twitter.user']}.xml" ){|f| f.read}
+				xml = open( "https://twitter.com/statuses/user_timeline/#{@conf['twitter.user']}.xml" ){|f| f.read}
 			rescue Exception
 			end
 		end


### PR DESCRIPTION
参考: https://github.com/tdiary/tdiary-contrib/issues/221#issuecomment-647002881

Close #221