### PR TITLE
openbd.rb: fix URL to amazon.co.jp

### DIFF
--- a/plugin/openbd.rb
+++ b/plugin/openbd.rb
@@ -104,7 +104,8 @@ module OpenBD
 		if isbn13
 			"https://www.hanmoto.com/bd/isbn/#{isbn13}"
 		else
-			"https://www.amazon.co.jp/dp/#{item.isbn}"
+			isbn = item.isbn.length == 13 ? isbn13to10(item.isbn) : item.isbn
+			"https://www.amazon.co.jp/dp/#{isbn}"
 		end
 	end
 
@@ -122,6 +123,12 @@ module OpenBD
 			width = 200 if !width && !height
 		end
 		{ url: url, width: width, height: height }
+	end
+
+	# from tdiary-core/lib/aws/pa_api.rb
+	def isbn13to10(isbn13)
+		sum, = isbn13[3, 9].split(//).map(&:to_i).reduce([0,10]){|s,d|[s[0] + d * s[1], s[1]-1]}
+		return isbn13[3, 9] + %w(0 1 2 3 4 5 6 7 8 9 X 0)[11 - sum % 11]
 	end
 end
 


### PR DESCRIPTION
openBDプラグインにて、APIで書籍情報を取得できない場合は amazon.co.jp へのリンクを生成するようにしているのですが、そのURLが正しくないケースがあったので修正します。

問題が発生するのはプラグインへ指定されたISBNがISBN-13だった場合です。

この場合ISBNをISBN-10に変換してURLを生成する必要があるので、そうなるように修正します。ISBN-13からISBN-10への変換処理はamazon.rbが使っているものをコピーしています。