### PR TITLE
add hack for image plugin in ogp

### DIFF
--- a/plugin/ogp.rb
+++ b/plugin/ogp.rb
@@ -41,6 +41,7 @@ def ogp_tag
 			section_index = @cgi.params['p'][0] || sections.size
             begin
 				section = sections[section_index.to_i - 1].body_to_html
+				@image_date = @date.strftime("%Y%m%d") # hack for image plugin
 				section_html = apply_plugin(section)
 
 				headers['og:description'] = ogp_description(section_html)


### PR DESCRIPTION
fix for https://github.com/tdiary/tdiary-core/issues/914
@image_date is make in body_enter_proc of image.rb, but apply_plugin does not call it.