### PR TITLE
Added the altanative implementation for jholiday.rb with holiday_japan

### DIFF
--- a/plugin/jholiday2.rb
+++ b/plugin/jholiday2.rb
@@ -1,0 +1,16 @@
+require 'holiday_japan'
+require 'date'
+unless Time::new.respond_to?( :strftime_holiday_backup )
+then
+ eval( <<-MODIFY_CLASS, TOPLEVEL_BINDING )
+  class Time
+   alias strftime_holiday_backup strftime
+   def strftime( format )
+    holiday = ""
+    day = Date.new(self.year, self.month, self.day)
+    holiday = HolidayJapan.name(day) if HolidayJapan.check(day)
+    strftime_holiday_backup( format.gsub( /%K/, holiday ) )
+   end
+  end
+ MODIFY_CLASS
+end


### PR DESCRIPTION
天皇の交代や各種祝日の法改正に対応した [holiday_japan](https://github.com/masa16/holiday_japan) を用いた jholiday2.rb というプラグインを追加します。いい名前が思いつかなかったので tDiary 伝統の ~2.rb という名前にしています。