### PR TITLE
Add Launchpad on OpenID plugin

### DIFF
--- a/plugin/openid.rb
+++ b/plugin/openid.rb
@@ -43,6 +43,7 @@ if /^(?:latest|conf|saveconf)$/ =~ @mode then
 			nil,
 			['https://open.login.yahooapis.com/openid/op/auth', 'https://me.yahoo.com/a/<ID>'],
 			'http://open.login.yahooapis.com/openid20/www.yahoo.com/xrds'),
+		'Launchpad' => @openid_config.new(['https://login.launchpad.net/+openid', 'https://login.launchpad.net/+id/<ID>']),
 	}
 
 	if @conf['openid.service'] and @conf['openid.id'] then


### PR DESCRIPTION
Ubuntu OneのLaunchpadのOpenIDプロバイダーは、まだ有効なのでOpenIDプラグインに追加しました。

いまさらOpenIDですが、2021年7月末で「[はてなIDのOpenIDサポート終了](https://hatena-announce.hatenastaff.com/entry/2021/01/22/101045)」ということなので、「wedataに入れなくなる」と慌てて代わりとなるサービスを探したところ、[Launchpad](https://launchpad.net/)ならまだやっていたので、OpenIDプラグインに追加してみました。
