### PR TITLE
Google Analyticsプラグインのanalytics.jsをgtags.jsへ変更する

### DIFF
--- a/plugin/google_analytics.rb
+++ b/plugin/google_analytics.rb
@@ -13,15 +13,15 @@ end
 def google_analytics_insert_code
 	return '' unless @conf['google_analytics.profile']
 	<<-HTML
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-#{@conf['google_analytics.profile']}"></script>
 	<script>
-		(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-		(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-		m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-		})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
 
-		ga('create', 'UA-#{@conf['google_analytics.profile']}', 'auto');
-		ga('send', 'pageview');
-	// --></script>
+			gtag('config', 'UA-#{@conf['google_analytics.profile']}');
+		</script>
 	HTML
 end
 

--- a/plugin/google_analytics.rb
+++ b/plugin/google_analytics.rb
@@ -15,7 +15,7 @@ def google_analytics_insert_code
 	<<-HTML
 		<!-- Global site tag (gtag.js) - Google Analytics -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=UA-#{@conf['google_analytics.profile']}"></script>
-	<script>
+		<script>
 			window.dataLayer = window.dataLayer || [];
 			function gtag(){dataLayer.push(arguments);}
 			gtag('js', new Date());
@@ -34,7 +34,7 @@ add_conf_proc( 'google_analytics', 'Google Analytics' ) do
 	r = <<-HTML
 		<h3>Google Analytics Profile</h3>
 		<p>set your Profile ID (NNNNN-N)</p>
-		<p><input name="google_analytics.profile" value="#{h @conf['google_analytics.profile']}"></p>
+		<p>UA-<input name="google_analytics.profile" value="#{h @conf['google_analytics.profile']}"></p>
 	HTML
 	if defined? AMP
 		r << <<-HTML

--- a/spec/google_analytics_spec.rb
+++ b/spec/google_analytics_spec.rb
@@ -44,15 +44,15 @@ describe "google_analytics plugin" do
 
 	def expected_html_footer_snippet
 		expected = <<-SCRIPT
-		<script>
-			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-			})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+			<!-- Global site tag (gtag.js) - Google Analytics -->
+			<script async src="https://www.googletagmanager.com/gtag/js?id=UA-53836-1"></script>
+			<script>
+				window.dataLayer = window.dataLayer || [];
+				function gtag(){dataLayer.push(arguments);}
+				gtag('js', new Date());
 
-			ga('create', 'UA-53836-1', 'auto');
-			ga('send', 'pageview');
-		// --></script>
+				gtag('config', 'UA-53836-1');
+			</script>
 		SCRIPT
 		expected.gsub( /^\t/, '' ).chomp
 	end


### PR DESCRIPTION
Google Analyticsプラグインを使用していたところ、Googleからgtagsを勧める通知が来たので、下記ドキュメントを参考に変更してみました。

- [analytics.js から gtag.js に移行する  |  ウェブ向けユニバーサル アナリティクス（gtag.js）](https://developers.google.com/analytics/devguides/collection/gtagjs/migration?hl=ja)